### PR TITLE
Make WindowSizingBoxes Customizable

### DIFF
--- a/WindowsSizingBoxes.cs
+++ b/WindowsSizingBoxes.cs
@@ -55,7 +55,7 @@ namespace EasyTabs
             return _minimizeButtonArea.Contains(cursor) || _maximizeRestoreButtonArea.Contains(cursor) || _closeButtonArea.Contains(cursor);
         }
 
-        public void Render(Graphics graphicsContext, Point cursor)
+        public virtual void Render(Graphics graphicsContext, Point cursor)
         {
             int right = _parentWindow.ClientRectangle.Width;
             bool closeButtonHighlighted = false;


### PR DESCRIPTION
With this simple change, other developers (like me) can customize close, maximize & minimize buttons by simply creating a class that inherits `WindowSizingBoxes` and overriding `Render`.
And yes this class is used for Windows 10 but this class can be used in any OS and button areas can be changed for each OS.